### PR TITLE
Fix kpis date mgmt

### DIFF
--- a/src/components/kpis-bar/kpis-bar.directive.coffee
+++ b/src/components/kpis-bar/kpis-bar.directive.coffee
@@ -76,10 +76,13 @@ angular
 
         initDatesPicker = ->
           $scope.datesPickerDeferred.promise.then((settingDatesPicker)->
-            ImpacKpisSvc.getKpisDateRange().then((dates)->
-              $scope.kpisDateRange.from = dates.from
-              $scope.kpisDateRange.to = dates.to
-              $scope.kpisDateRange.keepToday = dates.keepToday
+            ImpacKpisSvc.getKpisDateRange().then(
+              (dates)->
+                $scope.kpisDateRange.from = dates.from
+                $scope.kpisDateRange.to = dates.to
+                $scope.kpisDateRange.keepToday = dates.keepToday
+              ->
+                $scope.hideDatesPicker = true
             ).finally(->
               $scope.kpiDatesDeferred.resolve()
               settingDatesPicker.initialize()
@@ -157,6 +160,9 @@ angular
 
         $scope.hasKpiAvailability = ->
           $scope.availableKpis.list.length
+
+        $scope.showDatesPicker = ->
+          $scope.isEditing() && $scope.kpis.length && !$scope.hideDatesPicker
 
         # Private methods
         # -------------------------

--- a/src/components/kpis-bar/kpis-bar.tmpl.html
+++ b/src/components/kpis-bar/kpis-bar.tmpl.html
@@ -61,7 +61,7 @@
         </div>
       </div>
     </div>
-    <div class="row" ng-show="isEditing() && kpis.length">
+    <div class="row" ng-show="showDatesPicker()">
       <div class="dates-picker-container">
         <div setting-dates-picker from="kpisDateRange.from" to="kpisDateRange.to" keep-today="kpisDateRange.keepToday" on-change="kpisBarUpdateDates" deferred="datesPickerDeferred"/>
       </div>

--- a/src/services/kpis/kpis.svc.coffee
+++ b/src/services/kpis/kpis.svc.coffee
@@ -284,6 +284,7 @@ angular
       ).finally ( -> kpi.isLoading = false )
 
     @create = (source, endpoint, elementWatched, opts={}) ->
+      deferred = $q.defer()
       _self.load().then(
         ->
           params = {
@@ -310,15 +311,16 @@ angular
                 ImpacEvents.notifyCallbacks(IMPAC_EVENTS.addOrRemoveAlerts)
                 kpi = success.data
                 _self.buildKpiWatchables(kpi)
-                kpi
+                deferred.resolve(kpi)
               (err) ->
                 $log.error("Impac! - KpisSvc: Unable to create kpi endpoint=#{endpoint}", err)
-                $q.reject(err)
+                deferred.reject(err)
             )
           )
         ->
-          $q.reject({ error: {message: 'Impac! - KpisSvc: Service is not initialized'} })
+          deferred.reject({ error: {message: 'Impac! - KpisSvc: Service is not initialized'} })
       )
+      return deferred.promise
 
     @update = (kpi, params) ->
       kpi.isLoading = true


### PR DESCRIPTION
@cesar-tonnoir here is a fix for the `.finally` issues. It is now correctly working as intended with Impac! (tested and is matching the report requester). You cannot chain a value from a `.finally`, unless handled manually with a deferred I discovered. 

"a finally clause, allows you to observe either the fulfillment or rejection of a promise, but to do so without modifying the final value." - [api doc](https://github.com/kriskowal/q/wiki/API-Reference#promisefinallycallback)

The one case I have noticed though, is when disabling the kpis bar, the hist_parameters are left on the dashboard model.. So therefore the last saved values continue to be applied. I will look into this further tonight, just wanted to submit this PR for you before hand.

