### PR TITLE
Refactor highcharts-formatter to a Factory

### DIFF
--- a/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
@@ -36,7 +36,7 @@ module.component('chartThreshold', {
         ->
           disableAttachability()
       )
-      # Register to chart changes
+      # Register to chart changes (expects a highchart instance)
       ctrl.chartPromise.then(null, null, onChartNotify) if ctrl.chartPromise? && _.isFunction(ctrl.chartPromise.then)
 
     ctrl.createKpi = (target)->

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.directive.coffee
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.directive.coffee
@@ -1,5 +1,5 @@
 module = angular.module('impac.components.widgets.accounts-cash-balance', [])
-module.controller('WidgetAccountsCashBalanceCtrl', ($scope, $q, $timeout, $filter, ImpacTheming, HighChartsFormatter) ->
+module.controller('WidgetAccountsCashBalanceCtrl', ($scope, $q, $timeout, $filter, ImpacTheming, HighchartsFactory) ->
 
   w = $scope.widget
 
@@ -29,18 +29,18 @@ module.controller('WidgetAccountsCashBalanceCtrl', ($scope, $q, $timeout, $filte
     setSeriesColors(w.content.chart.series, { positive: '#3FC4FF', negative: '#e50228'})
 
   $scope.legendItemOnClick = (account)->
-    serie = $scope.chart && getSerieByAccount($scope.chart.series, account)
+    serie = $scope.chart? && $scope.chart.hc? && getSerieByAccount($scope.chart.hc.series, account)
     return unless serie
     visibility = if serie.visible then false else true
     serie.setVisible(visibility)
 
   $scope.getLegendItemIcon = (account)->
-    serie = $scope.chart && getSerieByAccount($scope.chart.series, account)
+    serie = $scope.chart? && $scope.chart.hc? && getSerieByAccount($scope.chart.hc.series, account)
     return 'fa-check-square-o' unless serie
     if serie.visible then 'fa-check-square-o' else 'fa-square-o'
 
   $scope.getLegendItemColor = (account)->
-    serie = $scope.chart && getSerieByAccount($scope.chart.series, account)
+    serie = $scope.chart? && $scope.chart.hc? && getSerieByAccount($scope.chart.hc.series, account)
     return '#000' unless serie
     serie.color
 
@@ -64,14 +64,17 @@ module.controller('WidgetAccountsCashBalanceCtrl', ($scope, $q, $timeout, $filte
   # Called after initContext - draws the chart using HighCharts
   w.format = ->
     options =
-      id: $scope.chartId
-      period: getPeriod()
+      chartType: 'line'
+      data: w.content.chart
       currency: w.metadata.currency
+      period: getPeriod()
       showToday: true
       showLegend: false
 
     $timeout ->
-      HighChartsFormatter.lineChart($scope, w.content.chart, options)
+      unless $scope.chart instanceof HighchartsFactory
+        $scope.chart = new HighchartsFactory($scope.chartId(), options)
+      $scope.chart.render(options)
 
 
   # Widget is ready: can trigger the "wait for settings to be ready"

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -1,5 +1,5 @@
 module = angular.module('impac.components.widgets.accounts-cash-projection', [])
-module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, ImpacKpisSvc, HighChartsFormatter) ->
+module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, ImpacKpisSvc, HighchartsFactory) ->
 
   w = $scope.widget
 
@@ -54,26 +54,29 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
 
   w.format = ->
     options =
-      id: $scope.chartId
-      period: getPeriod()
+      chartType: 'line'
+      data: w.content.chart
       currency: w.metadata.currency
+      period: getPeriod()
       showToday: true
       showLegend: true
       thresholds: getThresholds()
 
-    HighChartsFormatter.lineChart($scope, w.content.chart, options)
+    unless $scope.chart instanceof HighchartsFactory
+      $scope.chart = new HighchartsFactory($scope.chartId(), options)
+    $scope.chart.render(options)
 
-    $scope.chartDeferred.notify($scope.chart)
- 
-  $scope.chartId = -> 
+    $scope.chartDeferred.notify($scope.chart.hc)
+
+  $scope.chartId = ->
     "cashProjectionChart-#{w.id}"
- 
-  $scope.toggleSimulationMode = (init = false) -> 
-    $scope.initSettings() if init 
-    $scope.simulationMode = !$scope.simulationMode 
- 
-  $scope.saveSimulation = -> 
-    $scope.updateSettings() 
+
+  $scope.toggleSimulationMode = (init = false) ->
+    $scope.initSettings() if init
+    $scope.simulationMode = !$scope.simulationMode
+
+  $scope.saveSimulation = ->
+    $scope.updateSettings()
     $scope.toggleSimulationMode()
 
   getPeriod = ->

--- a/src/services/highcharts-formatter/highcharts-formatter.svc.coffee
+++ b/src/services/highcharts-formatter/highcharts-formatter.svc.coffee
@@ -1,103 +1,101 @@
 angular
 .module('impac.services.highcharts-formatter', [])
-.service('HighChartsFormatter', ($filter) ->
-  _self = @
+.factory('HighchartsFactory', ($filter)->
 
-  todayMarker = (dates, showToday) ->
-    return {} unless showToday
-    projection_date = _.find(dates, (date)-> moment(date) >= moment().startOf('day'))
-    todayIndex = _.indexOf(dates, projection_date)
-
-    xAxis:
-      plotLines: [{
-        color: 'rgba(0, 85, 255, 0.2)'
-        value: todayIndex
-        width: 1
-        label:
-          text: null
-          verticalAlign: 'top'
-          textAlign: 'center'
-          rotation: 0
-          y: -5
-      }]
-
-  thresholdsMarkers = (thresholds) ->
-    return {} if _.isEmpty(thresholds)
-    lines = []
-    for threshold in thresholds
-      lines.push({
-        color: 'rgba(255, 0, 0, 0.5)'
-        value: threshold
-        width: 2
-        zIndex: 5
-      })
-
-    yAxis:
-      plotLines: lines
-
-  formatters = (chartData, period, currency) ->
-    xAxis:
-      labels:
-        formatter: ->
-          $filter('mnoDate')(chartData.labels[this.value], period)
-    yAxis:
-      labels:
-        formatter: ->
-          $filter('mnoCurrency')(this.value, currency, false, 0)
-    tooltip:
-      formatter: ->
-        date = $filter('mnoDate')(chartData.labels[this.x], period)
-        amount = $filter('mnoCurrency')(this.y, currency, false)
-        name = this.series.name
-        # If point is in the past, "My Projected Stuff" => "My Stuff"
-        if moment(chartData.labels[this.x]) < moment().startOf('day')
-          name = _.startCase _.trim name.toLowerCase().replace(/\s*projected\s*/, ' ')
-        "<strong>#{date}</strong><br>#{name}: #{amount}"
-
-  # Creates or update a line chart and add it to your scope
-  # options:
-  #   id()        (required)
-  #   period      (required)
-  #   currency    (required)
-  #   showToday   (default false)
-  #   showLegend  (default false)
-  #   thresholds  (default empty)
-  @lineChart = (scope, chartData, options) ->
-    baseLineChart = 
-      chart:
-        type: 'line'
-        zoomType: 'x'
-        spacingTop: 20
-      title: null
-      credits:
-        enabled: false
-      legend:
-        enabled: options.showLegend
-        layout: 'vertical'
-        align: 'left'
-        verticalAlign: 'middle'
-      xAxis:
-        startOnTick: false
-        minPadding: 0
-        tickInterval: 1
-        min: 0
-      yAxis:
+  templates =
+    line: Object.freeze
+      get: (options = {})->
+        chart:
+          type: 'line'
+          zoomType: 'x'
+          spacingTop: 20
         title: null
-        startOnTick: true
-        minPadding: 0
-      series: chartData.series
+        credits:
+          enabled: false
+        legend:
+          enabled: _.get(options, 'showLegend', true)
+          layout: 'vertical'
+          align: 'left'
+          verticalAlign: 'middle'
+        xAxis:
+          startOnTick: false
+          minPadding: 0
+          tickInterval: 1
+          min: 0
+        yAxis:
+          title: null
+          startOnTick: true
+          minPadding: 0
+        series: _.get(options, 'data.series', [])
 
-    chartConfig = angular.merge(
-      baseLineChart,
-      todayMarker(chartData.labels, options.showToday),
-      thresholdsMarkers(options.thresholds),
-      formatters(chartData, options.period, options.currency)
-    )
+  class Chart
+    constructor: (@id, @options = {})->
+      @_template = templates[@options.chartType]
+      return
 
-    if _.isEmpty(scope.chart)
-      scope.chart = Highcharts.chart(options.id(), chartConfig)
-    else
-      scope.chart.update(chartConfig)
+    render: (options)->
+      angular.merge(@options, options)
+      chartConfig = angular.merge({},
+        @template(@options)
+        @formatters(@options)
+        @todayMarker(@options)
+        @thresholdsMarkers(@options)
+      )
+      if _.isEmpty(@hc)
+        @hc = Highcharts.chart(@id, chartConfig)
+      else
+        @hc.update(chartConfig)
+      return @
 
-  return @
+    template: (options = {})->
+      @_template.get(options)
+
+    formatters: (options = {})->
+      xAxis:
+        labels:
+          formatter: ->
+            $filter('mnoDate')(options.data.labels[this.value], options.period)
+      yAxis:
+        labels:
+          formatter: ->
+            $filter('mnoCurrency')(this.value, options.currency, false, 0)
+      tooltip:
+        formatter: ->
+          date = $filter('mnoDate')(options.data.labels[this.x], options.period)
+          amount = $filter('mnoCurrency')(this.y, options.currency, false)
+          name = this.series.name
+          # If point is in the past, "My Projected Stuff" => "My Stuff"
+          if moment(options.data.labels[this.x]) < moment().startOf('day')
+            name = _.startCase _.trim name.toLowerCase().replace(/\s*projected\s*/, ' ')
+          "<strong>#{date}</strong><br>#{name}: #{amount}"
+
+    todayMarker: (options = {})->
+      return {} unless options.showToday && !_.isEmpty(options.data)
+      projection_date = _.find(options.data.labels, (date)-> moment(date) >= moment().startOf('day'))
+      todayIndex = _.indexOf(options.data.labels, projection_date)
+      xAxis:
+        plotLines: [{
+          color: _.get(options, 'todayMarkerColor', 'rgba(0, 85, 255, 0.2)')
+          value: todayIndex
+          width: 1
+          label:
+            text: null
+            verticalAlign: 'top'
+            textAlign: 'center'
+            rotation: 0
+            y: -5
+        }]
+
+    thresholdsMarkers: (options = {})->
+      return {} if _.isEmpty(options.thresholds)
+      lines = []
+      for threshold in options.thresholds
+        lines.push({
+          color: _.get(options, 'thresholdsColor', 'rgba(255, 0, 0, 0.5)')
+          value: threshold
+          width: 2
+          zIndex: 5
+        })
+      "#{_.get(options, 'thresholdsMarkers.axis', 'yAxis')}":
+        plotLines: lines
 )


### PR DESCRIPTION
@cesar-tonnoir I had something in mind so I decided to try it out - please review. 

I believe using a factory and building new objects leveraging JS classes with instance methods gives us much more flexibility while keeping a strong defaults (thinking of what you said about getting closer to have 4 templates).

Within the PR you can see that the widget can do quite a bit of simple configuration just with the options object given to the chart on `new` & `render`. But below is an example of a bigger customisation that is now easily possible.

```coffeescript
unless $scope.chart instanceof HighchartsFactory
  $scope.chart = new HighchartsFactory($scope.chartId(), options)
$scope.chart.template = ->
  chart:
    type: 'line'
    zoomType: 'x'
    spacingTop: 20
  title: null
  credits:
    enabled: true
  legend:
    enabled: false
    layout: 'vertical'
    align: 'left'
    verticalAlign: 'middle'
  xAxis:
    startOnTick: false
    minPadding: 0
    tickInterval: 1
    min: 0
  yAxis:
    title: null
    startOnTick: true
    minPadding: 0
  series: _.get(options, 'data.series', [])
$scope.chart.render(options)
```
By doing the above, the chart instance has redefined its `template` instance method, allowing for complete template customisation, but still leveraging the other instance methods available on the chart object. The `render` will now internally call `this.template` returning the overridden hash.

The same thing can be done for the `formatters`, `todayMarker`, & `thresholdsMarkers` instance methods.

I have tested all features for both widgets & working well. 

Just incase you're not across it, [here is a good link](https://coffeescript-cookbook.github.io/chapters/classes_and_objects/class-methods-and-instance-methods) on coffeescript class instance & class methods.

:beers:
